### PR TITLE
Update for API 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <dependency>
         <groupId>org.spongepowered</groupId>
         <artifactId>spongeapi</artifactId>
-        <version>4.0.0-SNAPSHOT</version>
+        <version>4.0.3</version>
         <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/me/Flibio/EconomyLite/API/LiteCurrency.java
+++ b/src/me/Flibio/EconomyLite/API/LiteCurrency.java
@@ -49,4 +49,13 @@ public class LiteCurrency implements Currency {
 		}
 	}
 
+	@Override
+	public String getId() {
+		return "economylite:currency";
+	}
+
+	@Override
+	public String getName() {
+		return "EconomyLite Currency";
+	}
 }

--- a/src/me/Flibio/EconomyLite/API/LiteUniqueAccount.java
+++ b/src/me/Flibio/EconomyLite/API/LiteUniqueAccount.java
@@ -89,8 +89,10 @@ public class LiteUniqueAccount implements UniqueAccount {
 	}
 
 	@Override
-	public TransactionResult resetBalances(Cause cause, Set<Context> contexts) {
-		return resetBalance(liteCurrency,cause,contexts);
+	public Map<Currency, TransactionResult> resetBalances(Cause cause, Set<Context> contexts) {
+		Map<Currency, TransactionResult> map = new HashMap<>();
+		map.put(liteCurrency, resetBalance(liteCurrency,cause,contexts));
+		return map;
 	}
 
 	@Override

--- a/src/me/Flibio/EconomyLite/API/LiteVirtualAccount.java
+++ b/src/me/Flibio/EconomyLite/API/LiteVirtualAccount.java
@@ -91,8 +91,10 @@ public class LiteVirtualAccount implements VirtualAccount {
 	}
 
 	@Override
-	public TransactionResult resetBalances(Cause cause, Set<Context> contexts) {
-		return resetBalance(liteCurrency,cause,contexts);
+	public Map<Currency, TransactionResult> resetBalances(Cause cause, Set<Context> contexts) {
+		Map<Currency, TransactionResult> map = new HashMap<>();
+		map.put(liteCurrency, resetBalance(liteCurrency,cause,contexts));
+		return map;
 	}
 
 	@Override

--- a/src/me/Flibio/EconomyLite/Commands/AddCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/AddCommand.java
@@ -10,6 +10,7 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -63,7 +64,7 @@ public class AddCommand implements CommandExecutor {
 								return;
 							}
 							//Set the player's balance
-							if(account.setBalance(currency, BigDecimal.valueOf(newAmount), Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+							if(account.setBalance(currency, BigDecimal.valueOf(newAmount), Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 								//Successful
 								source.sendMessage(textUtils.successfulBalanceChangeText(playerName, newAmount));
 								return;

--- a/src/me/Flibio/EconomyLite/Commands/BusinessDeleteCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/BusinessDeleteCommand.java
@@ -11,6 +11,7 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -95,7 +96,7 @@ public class BusinessDeleteCommand implements CommandExecutor {
 											return;
 										} else {
 											UniqueAccount account = uOpt.get();
-											account.deposit(currency, BigDecimal.valueOf(eachGet), Cause.of("EconomyLite"));
+											account.deposit(currency, BigDecimal.valueOf(eachGet), Cause.of(NamedCause.owner(EconomyLite.access)));
 										}
 									}
 									return;

--- a/src/me/Flibio/EconomyLite/Commands/BusinessTransferCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/BusinessTransferCommand.java
@@ -11,6 +11,7 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -92,7 +93,7 @@ public class BusinessTransferCommand implements CommandExecutor{
 							player.sendMessage(textUtils.basicText("An internal error has occured!", TextColors.RED));
 							return;
 						}
-						if(!account.setBalance(currency, BigDecimal.valueOf(playerBalance+amount), Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+						if(!account.setBalance(currency, BigDecimal.valueOf(playerBalance+amount), Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 							player.sendMessage(textUtils.basicText("An internal error has occured!", TextColors.RED));
 							return;
 						}

--- a/src/me/Flibio/EconomyLite/Commands/PayCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/PayCommand.java
@@ -13,6 +13,7 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -133,7 +134,7 @@ public class PayCommand implements CommandExecutor{
 					return;
 				} else {
 					//Process transaction
-					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)&&
+					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)&&
 							businessManager.setBusinessBalance(businessName, newBalance)) {
 						//Success
                         player.sendMessage(textUtils.paySuccess(businessName, amount));
@@ -179,8 +180,8 @@ public class PayCommand implements CommandExecutor{
 					return;
 				} else {
 					//Process transaction
-					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)&&
-							targetAccount.setBalance(currency,BigDecimal.valueOf(newBalance),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)&&
+							targetAccount.setBalance(currency,BigDecimal.valueOf(newBalance),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 						//Success
 						player.sendMessage(textUtils.paySuccess(playerName, amount));
 						for(Player oPlayer : Sponge.getServer().getOnlinePlayers()) {

--- a/src/me/Flibio/EconomyLite/Commands/PayOverrideCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/PayOverrideCommand.java
@@ -13,6 +13,7 @@ import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -127,7 +128,7 @@ public class PayOverrideCommand implements CommandExecutor{
 					return;
 				} else {
 					//Process transaction
-					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)&&
+					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)&&
 							businessManager.setBusinessBalance(businessName, newBalance)) {
 						//Success
 						player.sendMessage(textUtils.paySuccess(businessName, amount));
@@ -173,8 +174,8 @@ public class PayOverrideCommand implements CommandExecutor{
 					return;
 				} else {
 					//Process transaction
-					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)&&
-							targetAccount.setBalance(currency,BigDecimal.valueOf(newBalance),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+					if(account.withdraw(currency,BigDecimal.valueOf(amount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)&&
+							targetAccount.setBalance(currency,BigDecimal.valueOf(newBalance),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 						//Success
 						player.sendMessage(textUtils.paySuccess(playerName, amount));
                         for(Player oPlayer : Sponge.getServer().getOnlinePlayers()) {

--- a/src/me/Flibio/EconomyLite/Commands/RemoveCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/RemoveCommand.java
@@ -10,6 +10,7 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -64,7 +65,7 @@ public class RemoveCommand implements CommandExecutor {
 								return;
 							}
 							//Set the player's balance
-							if(account.setBalance(currency,BigDecimal.valueOf(newAmount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+							if(account.setBalance(currency,BigDecimal.valueOf(newAmount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 								//Successful
 								source.sendMessage(textUtils.successfulBalanceChangeText(playerName, newAmount));
 								return;

--- a/src/me/Flibio/EconomyLite/Commands/SetCommand.java
+++ b/src/me/Flibio/EconomyLite/Commands/SetCommand.java
@@ -10,6 +10,7 @@ import org.spongepowered.api.command.CommandSource;
 import org.spongepowered.api.command.args.CommandContext;
 import org.spongepowered.api.command.spec.CommandExecutor;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.scheduler.Task.Builder;
 import org.spongepowered.api.service.economy.Currency;
 import org.spongepowered.api.service.economy.EconomyService;
@@ -61,7 +62,7 @@ public class SetCommand implements CommandExecutor {
 								return;
 							}
 							//Set the player's balance
-							if(account.setBalance(currency,BigDecimal.valueOf(amount),Cause.of("EconomyLite")).getResult().equals(ResultType.SUCCESS)) {
+							if(account.setBalance(currency,BigDecimal.valueOf(amount),Cause.of(NamedCause.owner(EconomyLite.access))).getResult().equals(ResultType.SUCCESS)) {
 								//Successful
 								source.sendMessage(textUtils.successfulBalanceChangeText(playerName, amount));
 								return;

--- a/src/me/Flibio/EconomyLite/EconomyLite.java
+++ b/src/me/Flibio/EconomyLite/EconomyLite.java
@@ -46,7 +46,7 @@ import java.util.HashMap;
 import java.util.Optional;
 
 @Updatifier(repoName = "EconomyLite", repoOwner = "Flibio", version = "v1.2.0")
-@Plugin(id = "EconomyLite", name = "EconomyLite", version = "1.2.0", dependencies = @Dependency(id = "Updatifier", optional = true))
+@Plugin(id = "me.flibio.economylite.economylite", name = "EconomyLite", version = "1.2.0", description = "EconmyLite provides simple economy handling.", dependencies = @Dependency(id = "Updatifier", optional = true))
 public class EconomyLite {
 	
 	@Inject

--- a/src/me/Flibio/EconomyLite/Events/BalanceChangeEvent.java
+++ b/src/me/Flibio/EconomyLite/Events/BalanceChangeEvent.java
@@ -1,7 +1,9 @@
 package me.Flibio.EconomyLite.Events;
 
+import me.Flibio.EconomyLite.EconomyLite;
 import org.spongepowered.api.event.Cancellable;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.impl.AbstractEvent;
 
 import java.util.UUID;
@@ -40,7 +42,7 @@ public class BalanceChangeEvent extends AbstractEvent implements Cancellable {
 
 	@Override
 	public Cause getCause() {
-		return Cause.of("EconomyLite");
+		return Cause.of(NamedCause.owner(EconomyLite.access));
 	}
 
 }

--- a/src/me/Flibio/EconomyLite/Events/LiteEconomyTransactionEvent.java
+++ b/src/me/Flibio/EconomyLite/Events/LiteEconomyTransactionEvent.java
@@ -1,6 +1,8 @@
 package me.Flibio.EconomyLite.Events;
 
+import me.Flibio.EconomyLite.EconomyLite;
 import org.spongepowered.api.event.cause.Cause;
+import org.spongepowered.api.event.cause.NamedCause;
 import org.spongepowered.api.event.economy.EconomyTransactionEvent;
 import org.spongepowered.api.service.economy.transaction.TransactionResult;
 
@@ -14,7 +16,7 @@ public class LiteEconomyTransactionEvent implements EconomyTransactionEvent {
 
 	@Override
 	public Cause getCause() {
-		return Cause.of("EconomyLite");
+		return Cause.of(NamedCause.owner(EconomyLite.access));
 	}
 
 	@Override


### PR DESCRIPTION
The 4.0.0-SNAPSHOT dependency didn't have everything that was in the final 4.0.x build - as a result, running this on a 4.1.0-SNAPSHOT server was failing - attempting to update someone's balance was failing, for example, because `Causes` had changed.

```
[15:26:37 ERROR] [Sponge]: The Scheduler tried to run the task EconomyLite-A-18 owned by Plugin{id=EconomyLite, name=EconomyLite, version=1.2.0, source=mods\EconomyLite-v1.2.0.jar}, but an error occured.
java.lang.NoSuchMethodError: org.spongepowered.api.event.cause.Cause.of(Ljava/lang/Object;[Ljava/lang/Object;)Lorg/spongepowered/api/event/cause/Cause;
        at me.Flibio.EconomyLite.Commands.SetCommand$1.run(SetCommand.java:64) ~[SetCommand$1.class:?]
        at org.spongepowered.api.scheduler.Task$Builder.lambda$execute$10(Task.java:138) ~[Task$Builder.class:1.8.9-4.1.0-BETA-268]
        at org.spongepowered.common.scheduler.SchedulerBase.lambda$startTask$255(SchedulerBase.java:177) ~[SchedulerBase.class:1.8.9-4.1.0-BETA-268]
        at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:1.8.0_60]
        at java.util.concurrent.FutureTask.run(Unknown Source) [?:1.8.0_60]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) [?:1.8.0_60]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) [?:1.8.0_60]
        at java.lang.Thread.run(Unknown Source) [?:1.8.0_60]
```

This commit updates to 4.0.3 and resolves all compile time issues.
