### PR TITLE
Implement `equals` to `LiteCurrency` and implement Cataloging

### DIFF
--- a/src/me/Flibio/EconomyLite/API/LiteCurrency.java
+++ b/src/me/Flibio/EconomyLite/API/LiteCurrency.java
@@ -58,4 +58,11 @@ public class LiteCurrency implements Currency {
 	public String getName() {
 		return "EconomyLite Currency";
 	}
+
+	@Override
+	public boolean equals(Object other) {
+		if(!(other instanceof Currency))
+			return false;
+		return this.getId().equals( ((Currency) other).getId() );
+	}
 }

--- a/src/me/Flibio/EconomyLite/EconomyLite.java
+++ b/src/me/Flibio/EconomyLite/EconomyLite.java
@@ -19,6 +19,7 @@ import me.Flibio.EconomyLite.Commands.RemoveCommand;
 import me.Flibio.EconomyLite.Commands.SetCommand;
 import me.Flibio.EconomyLite.Listeners.BalanceChangeListener;
 import me.Flibio.EconomyLite.Listeners.PlayerJoinListener;
+import me.Flibio.EconomyLite.Registry.CurrencyRegistryModule;
 import me.Flibio.EconomyLite.Utils.BusinessManager;
 import me.Flibio.EconomyLite.Utils.FileManager;
 import me.Flibio.EconomyLite.Utils.FileManager.FileType;
@@ -60,6 +61,7 @@ public class EconomyLite {
 	private BusinessManager businessManager;
 	private static EconomyService economyService;
 	private static Currency currency;
+	private static CurrencyRegistryModule currencyRegistryModule;
 	
 	public static EconomyLite access;
 	
@@ -104,6 +106,8 @@ public class EconomyLite {
 		game.getServiceManager().setProvider(this, EconomyLiteAPI.class, new EconomyLiteAPI());
 		economyService = new LiteEconomyService();
 		game.getServiceManager().setProvider(this, EconomyService.class, economyService);
+		currencyRegistryModule = new CurrencyRegistryModule();
+		game.getRegistry().registerModule(Currency.class, currencyRegistryModule);
 		logger.info("API registered successfully!");
 		//Reset business confirmations
 		game.getScheduler().createTaskBuilder().execute(new Runnable() {

--- a/src/me/Flibio/EconomyLite/Registry/CurrencyRegistryModule.java
+++ b/src/me/Flibio/EconomyLite/Registry/CurrencyRegistryModule.java
@@ -1,0 +1,23 @@
+package me.Flibio.EconomyLite.Registry;
+
+import me.Flibio.EconomyLite.EconomyLite;
+import org.spongepowered.api.registry.CatalogRegistryModule;
+import org.spongepowered.api.service.economy.Currency;
+
+import java.util.*;
+
+public class CurrencyRegistryModule implements CatalogRegistryModule<Currency> {
+
+    @Override
+    public Optional<Currency> getById(String id) {
+        Currency currency = EconomyLite.getCurrency();
+        if (currency.getId().equals(id))
+            return Optional.of(currency);
+        return Optional.empty();
+    }
+
+    @Override
+    public Collection<Currency> getAll() {
+        return Collections.singleton(EconomyLite.getCurrency());
+    }
+}


### PR DESCRIPTION
Solve #6 .

Implements Cataloging, as the `Currency` class has `CatalogType` implemented into it.

`CurrencyRegistryModule` could _easily_ be expanded to include multiple currencies, via
`Map<String, Currency>`, but because you only want to implement one for now I left it to just use that one.
